### PR TITLE
Update for the clarity of installation for Windows users

### DIFF
--- a/README_leetcode_generate.md
+++ b/README_leetcode_generate.md
@@ -44,7 +44,7 @@ $ pipenv install
 
 Edit your own username, password, language and repo in the **config.cfg.example** file and then rename it to **config.cfg**.
 
-driverpath - Please input the path of your chromedriver
+driverpath - Set the path of chromedriver. For Windows users, please include **chromedriver.exe** in path.
 
 ```
 [leetcode]


### PR DESCRIPTION
The driverpath setting guide is misleading to Windows users. The sample given implies that `chromedriver.exe` is not included in the path, which led to #33

By adding an additional line of reminder make it more user-friendly.