### PR TITLE
Use options instead of chrome_options

### DIFF
--- a/leetcode_generate.py
+++ b/leetcode_generate.py
@@ -206,7 +206,7 @@ class Leetcode:
         options.add_argument('--disable-gpu')
         executable_path = CONFIG.get('driverpath')
         driver = webdriver.Chrome(
-            chrome_options=options, executable_path=executable_path
+            options=options, executable_path=executable_path
         )
         driver.get(LOGIN_URL)
 


### PR DESCRIPTION
DeprecationWarning: use options instead of chrome_options

Environment:
ChromeDriver 92.0.4515.107
windows 10 x64, 
Python 3.8.9

Need to change **_chrome_options_** to **_options_** to run the program.